### PR TITLE
Replace the "[version]" in the body of the markdown, fix #37

### DIFF
--- a/scripts/_build/generator.js
+++ b/scripts/_build/generator.js
@@ -117,6 +117,9 @@ export async function makeGenerator() {
 		// fix links
 		body = body.replace(/\]\((?!\w+:\/\/)(.+?)\.md([)#])/gim, "]($1.html$2")
 
+		// update version
+		body = body.replaceAll("[version]", versions.mithril)
+
 		let markedHtml = marked(body)
 
 		// inject anchors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR enables the flems link to provide the current mithril version.

<!-- If you have questions about it, feel free to ask. We don't bite, I promise. -->
- [x] I have read https://mithril.js.org/contributing.html

## Description
<!--- Describe your changes in detail -->
The `[version]` added in https://github.com/MithrilJS/docs/commit/3811498babcfedd22ac7e33b787e9f9f2fa205e6 does not appear to have been converted to the version.

The existing replacement processing for the version does not seem to apply to the markdown body.
Also, the "[]" in the link will be encoded, so "[version]" must be replaced before marked conversion.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #37 
