### PR TITLE
Add missing argument for m.route

### DIFF
--- a/docs/route.md
+++ b/docs/route.md
@@ -95,10 +95,10 @@ var Article = {
 	}
 }
 
-m.route(document.body, {
-	'/article/:articleid': Article
+m.route(document.body, "/article/1", {
+	"/article/:articleid": Article
 })
-m.route.set('/article/:articleid', {articleid: 1})
+m.route.set("/article/:articleid", {articleid: 1})
 ```
 
 ##### m.route.get


### PR DESCRIPTION
`m.route()` was missing an argument in one of the examples.

- [x] I have read https://mithril.js.org/contributing.html

## Description

Added missing `defaultRoute` argument in one of the examples. Changed string quotation marks to double quotes so they are consistent with the rest of code snippets.

## Motivation and Context
* Incorrect use of `m.route()`
* String quotation marks are now consistent with the rest of examples
